### PR TITLE
fix sinon deprecated warnings

### DIFF
--- a/src/microservices/test/server/server-redis.spec.ts
+++ b/src/microservices/test/server/server-redis.spec.ts
@@ -18,7 +18,7 @@ describe('ServerRedis', () => {
             client = {
                 on: onSpy
             };
-            createRedisClient = sinon.stub(server, 'createRedisClient', () => client);
+            createRedisClient = sinon.stub(server, 'createRedisClient').callsFake(() => client);
         });
         it('should bind "connect" event to handler', () => {
             server.listen(null);
@@ -71,8 +71,8 @@ describe('ServerRedis', () => {
 
         beforeEach(() => {
             getPublisherSpy = sinon.spy();
-            sinon.stub(server, 'getPublisher', () => getPublisherSpy);
-            sinon.stub(server, 'tryParse', () => ({ data }))
+            sinon.stub(server, 'getPublisher').callsFake(() => getPublisherSpy);
+            sinon.stub(server, 'tryParse').callsFake(() => ({ data }));
         });
         it(`should publish NO_PATTERN_MESSAGE if pattern not exists in msgHandlers object`, () => {
             server.handleMessage(channel, {}, null);
@@ -92,7 +92,7 @@ describe('ServerRedis', () => {
         let publisherSpy: sinon.SinonSpy, handler;
         beforeEach(() => {
             publisherSpy = sinon.spy();
-            sinon.stub(server, 'getPublisher', () => publisherSpy);
+            sinon.stub(server, 'getPublisher').callsFake(() => publisherSpy);
             handler = server.getMessageHandlerCallback(null, null);
         });
         it(`should return function`, () => {

--- a/src/microservices/test/server/server-tcp.spec.ts
+++ b/src/microservices/test/server/server-tcp.spec.ts
@@ -13,7 +13,7 @@ describe('ServerTCP', () => {
         let getSocketInstance;
         const socket = { on: sinon.spy() };
         beforeEach(() => {
-            getSocketInstance = sinon.stub(server, 'getSocketInstance', () => socket);
+            getSocketInstance = sinon.stub(server, 'getSocketInstance').callsFake(() => socket);
         });
         it('should bind message event to handler', () => {
             server.bindHandler(null);


### PR DESCRIPTION
replace sinon.stub(instance, 'method', function) by sinon.stub(instance, 'method').callsFake(function) to avoid sinon warning