### PR TITLE
Change package.json to reflect project license

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "instrument": true
   },
   "author": "Kamil Mysliwiec",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "cli-color": "^1.1.0",
     "express": "^4.14.0",


### PR DESCRIPTION
Noticed that your License file says MIT but package.json said ISC. Just a quick change to sync those up.