### PR TITLE
Fix inject by string identifier

### DIFF
--- a/src/core/injector/module.ts
+++ b/src/core/injector/module.ts
@@ -111,12 +111,21 @@ export class Module {
 
     public addCustomClass(component: CustomClass) {
         const { provide: metatype, useClass } = component;
-        this._components.set(metatype.name, {
-            name: metatype.name,
+        const isMetatypeConstructor = Boolean(metatype.name)
+        const customClassEntry: any = {
+            name: null,
             metatype: useClass,
             instance: null,
             isResolved: false,
-        });
+        };
+
+        if (!isMetatypeConstructor) {
+            customClassEntry.name = metatype;
+        } else {
+            customClassEntry.name = metatype.name;
+        }
+
+        this._components.set(name, customClassEntry);
     }
 
     public addCustomValue(component: CustomValue) {


### PR DESCRIPTION
# Description
These commits fix the problem described in the issue #30 

The problem is that the incoming provide value from the component can either be a constructor or a string. Currently the **name** property is always used which results in undefined component set entries when a string is provided.

The fix is to check if the incoming metatype value is a constructor or a string value.